### PR TITLE
Modernize JS of examples

### DIFF
--- a/basic-fetch/index.html
+++ b/basic-fetch/index.html
@@ -8,9 +8,6 @@
     <title>Fetch basic example</title>
 
     <link rel="stylesheet" href="">
-    <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
   </head>
 
   <body>
@@ -19,26 +16,25 @@
     <img src="" class="my-image">
   </body>
   <script>
-    var myImage = document.querySelector('.my-image');
+    const myImage = document.querySelector('.my-image');
 
     fetch('flowers.jpg')
-    .then(function(response) {
+    .then((response) => {
       if (!response.ok) {
-        throw new Error('HTTP error, status = ' + response.status);
+        throw new Error(`HTTP error, status = ${response.status}`);
       }
       return response.blob();
     })
-    .then(function(myBlob) {
-      var objectURL = URL.createObjectURL(myBlob);
+    .then((myBlob) => {
+      const objectURL = URL.createObjectURL(myBlob);
       myImage.src = objectURL;
     })
-    .catch(function(error) {
-      var p = document.createElement('p');
+    .catch((error) => {
+      const p = document.createElement('p');
       p.appendChild(
-        document.createTextNode('Error: ' + error.message)
+        document.createTextNode(`Error: ${error.message}`)
       );
       document.body.insertBefore(p, myImage);
     });
-
   </script>
 </html>

--- a/fetch-array-buffer/index.html
+++ b/fetch-array-buffer/index.html
@@ -8,9 +8,6 @@
     <title>Fetch arrayBuffer example</title>
 
     <link rel="stylesheet" href="">
-    <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
   </head>
 
   <body>
@@ -23,31 +20,29 @@
     <pre></pre>
   </body>
   <script>
-    // define variables
-    var audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-    var source;
+    let source;
 
-    var pre = document.querySelector('pre');
-    var myScript = document.querySelector('script');
-    var play = document.querySelector('.play');
-    var stop = document.querySelector('.stop');
-    var errorDisplay = document.querySelector('.error');
+    const pre = document.querySelector('pre');
+    const myScript = document.querySelector('script');
+    const play = document.querySelector('.play');
+    const stop = document.querySelector('.stop');
+    const errorDisplay = document.querySelector('.error');
 
     // use fetch to load an audio track, and
     // decodeAudioData to decode it and stick it in a buffer.
     // Then we put the buffer into the source
     function getData() {
-      source = audioCtx.createBufferSource();
+      source = window.AudioContext.createBufferSource();
 
       return fetch('viper.ogg')
-      .then(function(response) {
+      .then((response) => {
         if (!response.ok) {
-          throw new Error("HTTP error, status = " + response.status);
+          throw new Error(`HTTP error, status = ${response.status}`);
         }
         return response.arrayBuffer();
       })
-      .then(function(buffer) {
-        audioCtx.decodeAudioData(buffer, function(decodedData) {
+      .then((buffer) => {
+        audioCtx.decodeAudioData(buffer, (decodedData) => {
           source.buffer = decodedData;
           source.connect(audioCtx.destination);
         });
@@ -55,27 +50,26 @@
     };
 
     // wire up buttons to stop and play audio
-    play.onclick = function() {
+    play.onclick = () => {
       getData()
-      .then(function() {
+      .then(() => {
         errorDisplay.innerHTML = '';
         source.start(0);
         play.disabled = true;
       })
-      .catch(function(error) {
+      .catch((error) => {
         errorDisplay.appendChild(
-          document.createTextNode('Error: ' + error.message)
+          document.createTextNode(`Error: ${error.message}`)
         );
       });
     };
 
-    stop.onclick = function() {
+    stop.onclick = () => {
       source.stop(0);
       play.disabled = false;
     };
 
     // dump script to pre element
     pre.innerHTML = myScript.innerHTML;
-
   </script>
 </html>

--- a/fetch-json/index.html
+++ b/fetch-json/index.html
@@ -8,9 +8,6 @@
     <title>Fetch json example</title>
 
     <link rel="stylesheet" href="style.css">
-    <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
   </head>
 
   <body>
@@ -20,31 +17,30 @@
 
   </body>
   <script>
-    var myList = document.querySelector('ul');
+    const myList = document.querySelector('ul');
 
     fetch('products.json')
-    .then(function(response) {
+    .then((response) => {
       if (!response.ok) {
-        throw new Error("HTTP error, status = " + response.status);
+        throw new Error(`HTTP error, status = ${response.status}`);
       }
       return response.json();
     })
     .then(function(data) {
-      for(var i = 0; i < data.products.length; i++) {
-        var listItem = document.createElement('li');
-        listItem.innerHTML = '<strong>' + data.products[i].Name + '</strong>';
-        listItem.innerHTML +=' can be found in ' + data.products[i].Location + '.';
-        listItem.innerHTML +=' Cost: <strong>£' + data.products[i].Price + '</strong>';
+      for(const product of data.products) {
+        const listItem = document.createElement('li');
+        listItem.innerHTML  = `<strong> ${product.Name} </strong>`;
+        listItem.innerHTML += ` can be found in ${product.Location}.`;
+        listItem.innerHTML += ` Cost: <strong>£${data.product.Price}</strong>`;
         myList.appendChild(listItem);
       }
     })
-    .catch(function(error) {
-      var p = document.createElement('p');
+    .catch((error) => {
+      const p = document.createElement('p');
       p.appendChild(
-        document.createTextNode('Error: ' + error.message)
+        document.createTextNode(`Error: ${error.message}`)
       );
       document.body.insertBefore(p, myList);
     });
-
   </script>
 </html>

--- a/fetch-request-with-init/index.html
+++ b/fetch-request-with-init/index.html
@@ -8,9 +8,6 @@
     <title>Fetch Request example with init</title>
 
     <link rel="stylesheet" href="">
-    <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
   </head>
 
   <body>
@@ -19,38 +16,36 @@
 
   </body>
   <script>
-    var myImage = document.querySelector('img');
+    const myImage = document.querySelector('img');
 
-    var myHeaders = new Headers();
+    const myHeaders = new Headers();
 
-    var myInit = {
+    const myOptions = {
       method: 'GET',
       headers: myHeaders,
       mode: 'cors',
       cache: 'default'
     };
 
-    var myRequest = new Request('flowers.jpg', myInit);
-    var myResponse;
+    const myRequest = new Request('flowers.jpg', myOptions);
 
     fetch(myRequest)
-    .then(function(response) {
+    .then((response) => {
       if (!response.ok) {
-        throw new Error("HTTP error, status = " + response.status);
+        throw new Error(`HTTP error, status = ${response.status}`);
       }
       return response.blob();
     })
-    .then(function(blob) {
-      var objectURL = URL.createObjectURL(blob);
+    .then((blob) => {
+      const objectURL = URL.createObjectURL(blob);
       myImage.src = objectURL;
     })
-    .catch(function(error) {
-      var p = document.createElement('p');
+    .catch((error) => {
+      const p = document.createElement('p');
       p.appendChild(
-        document.createTextNode('Error: ' + error.message)
+        document.createTextNode(`Error: ${error.message}`)
       );
       document.body.insertBefore(p, myImage);
     });
-
   </script>
 </html>

--- a/fetch-request/index.html
+++ b/fetch-request/index.html
@@ -35,6 +35,5 @@
       );
       document.body.insertBefore(p, myImage);
     });
-
   </script>
 </html>

--- a/fetch-response-clone/index.html
+++ b/fetch-response-clone/index.html
@@ -15,10 +15,6 @@
         margin: 0 10px;
       }
     </style>
-
-    <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
   </head>
 
   <body>
@@ -28,15 +24,15 @@
 
   </body>
   <script>
-    var image1 = document.querySelector('.img1');
-    var image2 = document.querySelector('.img2');
+    const image1 = document.querySelector('.img1');
+    const image2 = document.querySelector('.img2');
 
     fetch('flowers.jpg')
-    .then(function(response1) {
+    .then((response1) => {
       if (!response1.ok) {
-        showError(image1, "HTTP error, status = " + response1.status);
+        showError(image1, `HTTP error, status = ${response1.status}`);
       } else {
-        var response2 = response1.clone();
+        const response2 = response1.clone();
         useResponse(response1, image1);
         useResponse(response2, image2);
       }
@@ -44,22 +40,21 @@
 
     function useResponse(response, image) {
       response.blob()
-      .then(function(myBlob) {
-        var objectURL = URL.createObjectURL(myBlob);
+      .then((myBlob) => {
+        const objectURL = URL.createObjectURL(myBlob);
         image.src = objectURL;
       })
-      .catch(function(error) {
+      .catch((error) => {
           showError(image, error.message);
       });
     }
 
     function showError(image, errorMessage) {
-      var p = document.createElement('p');
+      const p = document.createElement('p');
       p.appendChild(
-        document.createTextNode('Error: ' + errorMessage)
+        document.createTextNode(`Error: ${errorMessage}`)
       );
       document.body.insertBefore(p, image);
     }
-
   </script>
 </html>

--- a/fetch-response/index.html
+++ b/fetch-response/index.html
@@ -8,9 +8,6 @@
     <title>Fetch basic response example</title>
 
     <link rel="stylesheet" href="">
-    <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
   </head>
 
   <body>
@@ -19,12 +16,12 @@
 
   </body>
   <script>
-    var myImage = document.querySelector('img');
+    const myImage = document.querySelector('img');
 
-    var myRequest = new Request('flowers.jpg');
+    const myRequest = new Request('flowers.jpg');
 
     fetch(myRequest)
-    .then(function(response) {
+    .then((response) => {
       console.log(response.type);
       console.log(response.url);
       console.log(response.useFinalURL);
@@ -33,25 +30,24 @@
       console.log(response.statusText);
       console.log(response.headers);
       if (!response.ok) {
-        throw new Error("HTTP error, status = " + response.status);
+        throw new Error(`HTTP error, status = ${response.status}`);
       }
       return response.blob();
     })
-    .then(function(myBlob) {
-      var objectURL = URL.createObjectURL(myBlob);
+    .then((myBlob) =>{
+      const objectURL = URL.createObjectURL(myBlob);
       myImage.src = objectURL;
     })
-    .catch(function(error) {
-      var p = document.createElement('p');
+    .catch((error) => {
+      const p = document.createElement('p');
       p.appendChild(
-        document.createTextNode('Error: ' + error.message)
+        document.createTextNode(`Error: ${error.message}`)
       );
       document.body.insertBefore(p, myImage);
     });
 
-    var myBlob = new Blob();
-    var init = { "status" : 200 , "statusText" : "SuperSmashingGreat!" }
-    var myResponse = new Response(myBlob, init);
-
+    const myBlob = new Blob();
+    const options = { "status" : 200 , "statusText" : "SuperSmashingGreat!" }
+    const myResponse = new Response(myBlob, options);
   </script>
 </html>

--- a/fetch-text/index.html
+++ b/fetch-text/index.html
@@ -8,9 +8,6 @@
     <title>Fetch text example</title>
 
     <link rel="stylesheet" href="style.css">
-    <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
   </head>
 
   <body>
@@ -25,34 +22,34 @@
 
   </body>
   <script>
-    var myArticle = document.querySelector('article');
-    var myLinks = document.querySelectorAll('ul a');
-    for(var i = 0; i <= myLinks.length - 1; i++) {
-      myLinks[i].onclick = function(e) {
+    const myArticle = document.querySelector('article');
+    const myLinks = document.querySelectorAll('ul a');
+    for(const link of myLinks) {
+      link.onclick = (e) => {
         e.preventDefault();
-        var linkData = e.target.getAttribute('data-page');
+        const linkData = e.target.getAttribute('data-page');
         getData(linkData);
       }
     };
 
     function getData(pageId) {
       console.log(pageId);
-      var myRequest = new Request(pageId + '.txt');
+      const myRequest = new Request(`${pageId}.txt`);
 
       fetch(myRequest)
-      .then(function(response) {
+      .then((response) => {
         if (!response.ok) {
-          throw new Error("HTTP error, status = " + response.status);
+          throw new Error(`HTTP error, status = ${response.status}`);
         }
         return response.text();
       })
-      .then(function(text) {
-        myArticle.innerHTML = text;
+      .then((text) => {
+        myArticle.innerText = text;
       })
-      .catch(function(error) {
-        myArticle.innerHTML = '';
+      .catch((error) => {
+        myArticle.innerText = '';
         myArticle.appendChild(
-          document.createTextNode('Error: ' + error.message)
+          document.createTextNode(`Error: ${error.message}`)
         );
       });
     }

--- a/fetch-with-init-then-request/index.html
+++ b/fetch-with-init-then-request/index.html
@@ -8,9 +8,6 @@
     <title>Fetch with init then Request example</title>
 
     <link rel="stylesheet" href="">
-    <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
   </head>
 
   <body>
@@ -19,35 +16,35 @@
 
   </body>
   <script>
-    var myImage = document.querySelector('img');
+    const myImage = document.querySelector('img');
 
-    var myHeaders = new Headers();
+    const myHeaders = new Headers();
     myHeaders.append('Content-Type', 'image/jpeg');
 
-    var myInit = {
+    const myOptions = {
       method: 'GET',
       headers: myHeaders,
       mode: 'cors',
       cache: 'default'
     };
 
-    var myRequest = new Request('flowers.jpg');
+    const myRequest = new Request('flowers.jpg');
 
-    fetch(myRequest, myInit)
-    .then(function(response) {
+    fetch(myRequest, myOptions)
+    .then((response) => {
       if (!response.ok) {
-        throw new Error("HTTP error, status = " + response.status);
+        throw new Error(`HTTP error, status = ${response.status}`);
       }
       return response.blob();
     })
-    .then(function(blob) {
-      var objectURL = URL.createObjectURL(blob);
+    .then((blob) => {
+      const objectURL = URL.createObjectURL(blob);
       myImage.src = objectURL;
     })
-    .catch(function(error) {
+    .catch((error) => {
       var p = document.createElement('p');
       p.appendChild(
-        document.createTextNode('Error: ' + error.message)
+        document.createTextNode(`Error: ${error.message}`)
       );
       document.body.insertBefore(p, myImage);
     });

--- a/object-fit-gallery-fetch/index.html
+++ b/object-fit-gallery-fetch/index.html
@@ -8,9 +8,6 @@
     <title>Object-fit gallery Fetch()</title>
 
     <link rel="stylesheet" href="style.css">
-    <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
   </head>
 
   <body>

--- a/object-fit-gallery-fetch/main.js
+++ b/object-fit-gallery-fetch/main.js
@@ -1,61 +1,37 @@
-var thumbs = document.querySelectorAll('.thumb');
-var mainImg = document.querySelector('.main');
+const thumbs = document.querySelectorAll('.thumb');
+const mainImg = document.querySelector('.main');
 
-for(var i = 1; i <= thumbs.length ; i++) {
-  var requestObj = 'images/pic' + i + '.jpg';
-  retrieveImage(requestObj, i - 1);
-}
+thumbs.forEach((thumb, index) => {
+  const requestObj = `images/pic${index}.jpg`;
 
-function retrieveImage(requestObj, imageNo) {
   fetch(requestObj)
-  .then(response => {
+  .then((response) => {
     if (!response.ok) {
-      throw new Error("HTTP error, status = " + response.status);
+      throw new Error(`HTTP error, status = ${response.status}`);
     }
     return response.blob();
   })
-  .then(blob => displayImage(imageNo, blob))
-  .catch(error => {
-    thumbs[imageNo].title = 'Image load failed: ' + error.message;
+  .then((blob) => displayImage(thumb, blob))
+  .catch((error) => {
+    thumb.title = `Image load failed: ${error.message}`;
   });
-}
+});
 
-function displayImage(imageNo, blob) {
-  var objectURL = URL.createObjectURL(blob);
-  thumbs[imageNo].setAttribute('src', objectURL);
-  thumbs[imageNo].onclick = function() {
+function displayImage(currentThumb, blob) {
+  const objectURL = URL.createObjectURL(blob);
+  currentThumb.setAttribute('src', objectURL);
+  currentThumb.onclick = () => {
     mainImg.setAttribute('src', objectURL);
     mainImg.className = 'blowup';
-    for(var i = 0; i < thumbs.length; i++) {
-      thumbs[i].className = 'thumb darken';
+    for(const thumb of thumbs) {
+      thumbs.className = 'thumb darken';
     }
   }
 }
 
-// The XHR version follows: much more complex
-
-// function retrieveImage(requestObj,imageNo) {
-//   var request = new XMLHttpRequest();
-//   request.open('GET', requestObj, true);
-//   request.responseType = 'blob';
-//   request.send();
-
-//   request.onload = function() {
-//     var objectURL = URL.createObjectURL(request.response);
-//     thumbs[imageNo].setAttribute('src',objectURL);
-//     thumbs[imageNo].onclick = function() {
-//       mainImg.setAttribute('src',objectURL);
-//       mainImg.className = 'blowup';
-//         for(i = 0; i < thumbs.length; i++) {
-//           thumbs[i].className = 'thumb darken';
-//         }
-//     }
-//   }
-// }
-
-mainImg.onclick = function() {
+mainImg.onclick = () => {
   mainImg.className = 'main';
-  for(var i = 0; i < thumbs.length; i++) {
-    thumbs[i].className = 'thumb';
+  for(const thumb of thumbs) {
+    thumb.className = 'thumb';
   }
 }


### PR DESCRIPTION
In order to fix the mdn/content counterpart, this PR updates the examples by:

- switch to `const` (or `let)` where possible (no more `var` statements).
- use `for...of` instead of `for(;;)`. (In one case, as the index was needed, I used a `forEach()` construct.
- do not use `function` when defining anonymous functions, but _arrow functiona_.
- use _template literals_.
- remove HTML code for pre-IE9 browsers (It is 2022…)
- don't use a prefix with a standard feature (Web Audio API is now supported by every browser without prefix).

@josh-cena, can you review this? (You and I don't have approval/merge here, but that's not a big deal as this repository will be merged with mdn/dom-examples somewhen in the next few weeks).

This should allow us to review mdn/content#17914.

@AMDFreak: You have expressed interest in seeing these examples updated in https://github.com/mdn/mdn-community/discussions/146. Can you have a look at this PR too, I'm interested in your feedback. We may miss a new feature to use and that's always interesting to have fresh eyes looking at such work. Thank you. (Funny how your comment about _fetch_ examples came exactly in the middle of our work on modernizing it!) (Note that we are tracking how we want to modernize our JS at https://github.com/mdn/mdn-community/discussions/143.